### PR TITLE
Add Toph to list of online judges

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ If you want to contribute, please read the [contribution guidelines] (https://gi
 * [Codeforces ](http://codeforces.com/) - The only programming contests Web 2.0 platform
 * [CoderByte](http://www.coderbyte.com/) - A decent website with algorithm challenges from beginner to advanced levels. Supports most of the popular languages like C++, python, javascript, ruby. 
 * [ShareCode.io ](https://sharecode.io/) - Online Judge and contest host with a lot of algorithmic problems in the archive to practice.
+* [Toph](https://toph.ws/) - Sport programming platform for online contests. It also has a growing problem archive.
 
 ## Tools
 


### PR DESCRIPTION
Hi,

I was wondering if you will be willing to add [Toph](https://toph.ws) to the list of online judges.

Toph is a relatively new (a little over an year old) sport programming platform. In this time, Toph has hosted [quite a number of programming contests](https://toph.ws/contests). It's arena is real-time, making the contestants' experience as pleasant as possible. Toph also has a [growing problem archive](https://toph.ws/problems) that allows problem solvers to practice and improve their skills. Beyond these, Toph's other functionalities (ability to form teams and participate in contests as team) builds on that experience. Hosting a contest on Toph is also very enjoyable with its powerful contest dashboard for administrators and contest moderators, integration with external tools like Slack, and so on.

At the time of writing this, Toph has processed [15800+ submissions](https://toph.ws/submissions).

Looking forward to hear your thoughts.

Best regards,