### PR TITLE
request to add erdos graph algorithms framework in Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If you want to contribute, please read the [contribution guidelines] (https://gi
     * [by @psjava](https://github.com/psjava/psjava)
     * [by @jeandersonbc](https://github.com/jeandersonbc/algorithms-and-ds)
     * [by @pedrovgs](https://github.com/pedrovgs/Algorithms)
+    * [by @Erdos-Graph-Framework](https://github.com/Erdos-Graph-Framework/Erdos)
 * JavaScript
     * [by @felipernb](https://github.com/felipernb/algorithms.js)
     * [by @nzakas](https://github.com/nzakas/computer-science-in-javascript)


### PR DESCRIPTION
Hi, will you please consider [**Erdos**](https://github.com/Erdos-Graph-Framework/Erdos) ?

[**Erdos**](https://github.com/Erdos-Graph-Framework/Erdos) is a very light, modular and super easy to use modern Graph theoretic algorithms framework for Java. It contains graph algorithms that you can apply swiftly with **one line of code** and was primarily developed to back a worker manager tasks for various Java projects including one in Android. 

Erdos was written because other frameworks in Java were very hard to get started with or just plain heavy (overhead wise) or just too opinionated. Erdos let the developer design it's own graph engines to optimise the runtime and comes with all of the graph algorithms you can expect.

all the best