### PR TITLE
Added Toph OJ under Online Judges

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ If you want to contribute, please read the [contribution guidelines](https://git
 * [Snakify](https://snakify.org/) - An introductory Python course with 100+ algorithmic problems and a step-by-step debugger (from Russia).
 * [SPOJ](http://www.spoj.com/) - More problems.
 * [TopCoder](https://www.topcoder.com/) - Lots of problems and real world/money worthy problems in Graphic Design, Data Science and Development.
+* [Toph](https://toph.co/) - Bangladeshi Online Judge. Holds online contests on a regular basis.
 * [URI](https://www.urionlinejudge.com.br/judge/login) - Brazilian Online Judge. Not so much problems, but it's growing and it has online contests.
 * [UVA](https://uva.onlinejudge.org/) - Hundreds of problems (from previous ACM-ICPC Regionals, World Finals and others).
 


### PR DESCRIPTION
Hello @tayllan. I've added a link to the Toph online judge (https://toph.co/) under Online Judges. Please merge this pr.