### PR TITLE
Change the link of CodeChef to more recent and better place

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you want to contribute, please read the [contribution guidelines](https://git
 
 * [A Visual Guide to Graph Traversal Algorithms](https://workshape.github.io/visual-graph-algorithms/) - Interactive visualizations for learning how graph traversal algorithms work.
 * [W3School](https://www.w3schools.in/data-structures-tutorial/intro/) - Data Structures tutorial.
-* [CodeChef](https://www.codechef.com/LEARNDSA/) - Learning DSA by practice on Codechef
+* [CodeChef](https://www.codechef.com/roadmap/algorithms) - Learning DSA by practice on Codechef
 * [Algorithm Visualizer](http://algo-visualizer.jasonpark.me/) - Dozens of animated algorithms (with code), and you can also create your own.
 * [Algorithms Visualization](http://bost.ocks.org/mike/algorithms/) - A dense article on Algorithms Visualization.
 * [Big-O Cheat Sheet](http://bigocheatsheet.com/) - Big-O complexities of common algorithms used in Computer Science.


### PR DESCRIPTION
The existing LEARNDSA url is pretty old and not updated anymore. Have added the more recent algorithms roadmap.