### PR TITLE
Add TakeUForward DSA Course Link to Resources Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ If you want to contribute, please read the [contribution guidelines](https://git
 * [MIT 18-409 - Topics in Theoretical Computer Science: An Algorithmist's Toolkit](https://ocw.mit.edu/courses/18-409-topics-in-theoretical-computer-science-an-algorithmists-toolkit-fall-2009/) - It covers a collection of geometric techniques that apply broadly in modern algorithm design.
 * [Udacity Intro to Algorithms](https://www.udacity.com/course/intro-to-algorithms--cs215) - Python-based Algorithms course.
 * [Algorithms in Motion](https://www.manning.com/livevideo/algorithms-in-motion) - Beginner's algorithms course with fun illustrations, based on the book Grokking Algorithms
+* [takeuforward](https://takeuforward.org/strivers-a2z-dsa-course/strivers-a2z-dsa-course-sheet-2/) This course is made for people who want to learn DSA from A to Z for free in a well-organized and structured manner
 * ~~[YogiBearian YouTube Channel](https://www.youtube.com/channel/UCv3Kd0guxD5KWQtP---9D6g) - Lots of well-explained videos on various computer science subjects.~~ _Account terminated due to violations of Youtube Policies._
 
 ## Books


### PR DESCRIPTION
This PR adds the TakeUForward DSA Course link (https://takeuforward.org/strivers-a2z-dsa-course/strivers-a2z-dsa-course-sheet-2/) to the resources section. The course is designed to teach Data Structures and Algorithms (DSA) from the ground up, making it an excellent resource for beginners. The link directs users to a comprehensive guide that covers DSA concepts from A to Z, following a structured learning path. This addition aims to provide learners with an accessible and well-structured resource to enhance their understanding of DSA.