### PR TITLE
Update book link - Introduction to Algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you want to contribute, please read the [contribution guidelines](https://git
 * [Data Structures Using C](http://www.amazon.com/Data-Structures-Using-Aaron-Tenenbaum/dp/0131997467) - The basic concepts and usages of data structures.
 * [Elementary Algorithms](https://github.com/liuxinyu95/AlgoXY) - An awesome book about algorithms and data structures.
 * [Grokking Algorithms](http://www.manning.com/bhargava) - An illustrated book on algorithms with practical examples.
-* [Introduction to Algorithms](http://mitpress.mit.edu/books/introduction-algorithms) - Essential!
+* [Introduction to Algorithms](https://mitpress.mit.edu/9780262046305/introduction-to-algorithms/) - Essential!
 * [Real World Algorithms: A Beginner's Guide](https://mitpress.mit.edu/books/real-world-algorithms) - An introduction to algorithms for readers with no background in advanced mathematics or computer science.
 * [Swift Algorithms & Data Structures](http://shop.waynewbishop.com/) - A practical guide to concepts, theory, and code.
 * [The Algorithm Design Manual](http://www.algorist.com/) - Easy to read and full of real-world examples.


### PR DESCRIPTION
I updated the URL to the book's latest edition because the linked edition is no longer available (see attached screenshot). 

<img width="1440" alt="Screenshot 2025-05-29 at 04 07 24" src="https://github.com/user-attachments/assets/93cbc80f-407e-483d-8491-b8e1ac96d5cf" />
