### PR TITLE
Added Learngraphtheory.org to the "Websites you should use to learn classic algorithms" section. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ If you want to contribute, please read the [contribution guidelines](https://git
 * [Stoimen's web log](http://www.stoimen.com/) - Some algorithms nicely explained.
 * [The Sound of Sorting](http://panthema.net/2013/sound-of-sorting/) - The Sound of Sorting - "Audibilization" and Visualization of Sorting Algorithms
 * [VisuAlgo](http://visualgo.net) - Visualising data structures and algorithms through animation.
+* [LearnGraphTheory](https://learngraphtheory.org/) - Interactive Algorithm Visualizer | Graph Theory Learning Platform.
 * [Wikipedia - Algorithms](https://en.wikipedia.org/wiki/List_of_algorithms) - Of course!!
 * [Wikipedia - Data Structures](https://en.wikipedia.org/wiki/List_of_data_structures) - and why not ?!!
 * [Learnersbucket](https://learnersbucket.com/) - Tutorials on data structures and algorithms in Javascript.


### PR DESCRIPTION
It’s a free, interactive platform that offers structured lessons and visualizations for learning graph theory. Suitable for students, developers, and self-learners interested in algorithms, discrete math, or networks.