### PR TITLE
Add Coding Interview Patterns open guide to Cheat Sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If you want to contribute, please read the [contribution guidelines](https://git
 * [CLRS in short](https://sinon.org/algorithms//#data-structures)
 * [Rice university DS course in short](https://www.clear.rice.edu/comp160/data1.html)
 * [Algo Deck](https://github.com/teivah/algodeck/) - An open-source collection of +200 algorithmic cards.
+* [Coding Interview Patterns](https://github.com/ExporaCloud/coding-interview-patterns) - Open guide to the 7 core interview patterns with triggers, classic LeetCode problems, complexity, and a decision framework.
 
 ## Related Awesome List
 


### PR DESCRIPTION
A free and open guide (MIT) to the 7 patterns behind most coding interview problems. Each pattern documents the structural trigger, the classic LeetCode problems, complexity, and the distinctions between similar patterns (sliding window vs two pointers, BFS vs Dijkstra). It also includes a decision framework, a combining-patterns doc for hybrid problems, and a complexity cheatsheet. No paywall, fully open on GitHub.

I placed it under Cheat Sheet alongside the other open GitHub reference repos (Tech Interview Cheat Sheet, Algo Deck). Happy to move it to a different section if you prefer.